### PR TITLE
fix : timer not correct for certain game modes

### DIFF
--- a/Assets/Scripts/game manager/GameRules.cs
+++ b/Assets/Scripts/game manager/GameRules.cs
@@ -116,6 +116,10 @@ public class GameRules : MonoBehaviour
             setTimer(GameOptions.customTimer);
             //customTimer = GameOptions.customTimer;
         }
+        else
+        {
+            setTimer(120);
+        }
 
         GameModeRequiresConsecutiveShots = GameOptions.gameModeRequiresConsecutiveShot;
         //Debug.Log("GameOptions.gameModeRequiresConsecutiveShot : " + GameOptions.gameModeRequiresConsecutiveShot);

--- a/Assets/Scripts/scene_start/StartManager.cs
+++ b/Assets/Scripts/scene_start/StartManager.cs
@@ -802,7 +802,10 @@ public class StartManager : MonoBehaviour
             Debug.Log("modeSelectedData[modeSelectedIndex].CustomTimer : " + modeSelectedData[modeSelectedIndex].CustomTimer);
             GameOptions.customTimer = modeSelectedData[modeSelectedIndex].CustomTimer;
         }
-
+        else
+        {
+            GameOptions.customTimer = 0;
+        }
 
         GameOptions.gameModeRequiresMoneyBall = modeSelectedData[modeSelectedIndex].ModeRequiresMoneyBall;
         GameOptions.gameModeRequiresConsecutiveShot = modeSelectedData[modeSelectedIndex].ModeRequiresConsecutiveShots;


### PR DESCRIPTION
when selecting a game mode requiring a custom timer (ex, 3 point contest), would always trigger condition about any game mode requiring a custom timer which would still be set to previous custom timer.

this resets condition and is a bit of a hack